### PR TITLE
Add RPM spec file and CI workflow for RPM publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,121 @@
+name: Build
+
+# Reusable build workflow.
+#
+# Used by:
+#   - ci.yml      (PR / push to main, no artifact uploads)
+#   - release.yml (tag push, with artifact uploads for the GH Release)
+#
+# Always runs fmt, clippy, tests and a release build for native + cross targets.
+# When `upload_artifacts: true`, also builds .deb packages and uploads
+# binaries + .debs as workflow artifacts.
+
+on:
+  workflow_call:
+    inputs:
+      upload_artifacts:
+        description: "Build .deb packages and upload binaries/debs as artifacts"
+        type: boolean
+        default: false
+
+env:
+  CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  native:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.94.0
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install ALSA dev
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+
+      - name: Format
+        run: cargo fmt --check
+
+      - name: Clippy
+        run: cargo clippy --no-default-features --features alsa -- -D warnings
+
+      - name: Test
+        run: cargo test --no-default-features --features alsa
+
+      - name: Build release binary
+        run: cargo build --release --no-default-features --features alsa
+
+      - name: Build .deb package
+        if: inputs.upload_artifacts
+        run: |
+          cargo install cargo-deb --locked
+          cargo deb --no-build --no-default-features
+
+      - name: Rename binary
+        if: inputs.upload_artifacts
+        run: cp target/release/rusty_lights rusty_lights-x86_64-linux
+
+      - name: Upload binary
+        if: inputs.upload_artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: rusty_lights-x86_64-linux
+          path: rusty_lights-x86_64-linux
+
+      - name: Upload .deb
+        if: inputs.upload_artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: deb-amd64
+          path: target/debian/*.deb
+
+  cross:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+            name: rusty_lights-aarch64-linux
+            deb_arch: arm64
+          - target: armv7-unknown-linux-gnueabihf
+            name: rusty_lights-armv7-linux
+            deb_arch: armhf
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.94.0
+
+      - name: Install cross
+        run: cargo install cross --locked
+
+      - name: Install cargo-deb
+        if: inputs.upload_artifacts
+        run: cargo install cargo-deb --locked
+
+      - name: Build release binary
+        run: cross build --release --target ${{ matrix.target }} --no-default-features --features alsa
+
+      - name: Build .deb package
+        if: inputs.upload_artifacts
+        run: cargo deb --no-build --no-default-features --target ${{ matrix.target }}
+
+      - name: Rename binary
+        if: inputs.upload_artifacts
+        run: cp target/${{ matrix.target }}/release/rusty_lights ${{ matrix.name }}
+
+      - name: Upload binary
+        if: inputs.upload_artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}
+          path: ${{ matrix.name }}
+
+      - name: Upload .deb
+        if: inputs.upload_artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: deb-${{ matrix.deb_arch }}
+          path: target/${{ matrix.target }}/debian/*.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,49 +4,6 @@ on:
   push:
   pull_request:
 
-env:
-  CARGO_TERM_COLOR: always
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.94.0
-        with:
-          components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Install ALSA dev
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
-
-      - name: Format
-        run: cargo fmt --check
-
-      - name: Clippy
-        run: cargo clippy --no-default-features --features alsa -- -D warnings
-
-      - name: Build
-        run: cargo build --no-default-features --features alsa
-
-      - name: Test
-        run: cargo test --no-default-features --features alsa
-
-  cross-check:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - aarch64-unknown-linux-gnu
-          - armv7-unknown-linux-gnueabihf
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.94.0
-
-      - name: Install cross
-        run: cargo install cross --locked
-
-      - name: Build
-        run: cross build --release --target ${{ matrix.target }} --no-default-features --features alsa
+  build:
+    uses: ./.github/workflows/build.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,84 +22,13 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  build-native:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.94.0
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
-
-      - name: Build release binary
-        run: cargo build --release --no-default-features --features alsa
-
-      - name: Build .deb package
-        run: |
-          cargo install cargo-deb --locked
-          cargo deb --no-build --no-default-features
-
-      - name: Rename binary
-        run: cp target/release/rusty_lights rusty_lights-x86_64-linux
-
-      - name: Upload binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: rusty_lights-x86_64-linux
-          path: rusty_lights-x86_64-linux
-
-      - name: Upload .deb
-        uses: actions/upload-artifact@v4
-        with:
-          name: deb-amd64
-          path: target/debian/*.deb
-
-  build-cross:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: aarch64-unknown-linux-gnu
-            name: rusty_lights-aarch64-linux
-            deb_arch: arm64
-          - target: armv7-unknown-linux-gnueabihf
-            name: rusty_lights-armv7-linux
-            deb_arch: armhf
-
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.94.0
-
-      - name: Install cross and cargo-deb
-        run: |
-          cargo install cross --locked
-          cargo install cargo-deb --locked
-
-      - name: Build release binary
-        run: cross build --release --target ${{ matrix.target }} --no-default-features --features alsa
-
-      - name: Build .deb package
-        run: cargo deb --no-build --no-default-features --target ${{ matrix.target }}
-
-      - name: Rename binary
-        run: cp target/${{ matrix.target }}/release/rusty_lights ${{ matrix.name }}
-
-      - name: Upload binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.name }}
-          path: ${{ matrix.name }}
-
-      - name: Upload .deb
-        uses: actions/upload-artifact@v4
-        with:
-          name: deb-${{ matrix.deb_arch }}
-          path: target/${{ matrix.target }}/debian/*.deb
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      upload_artifacts: true
 
   release:
-    needs: [build-native, build-cross]
+    needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
             | xargs -n1 basename | sed 's/\.cfg$//')
           echo "Using mock config: ${MOCK_CFG}"
           echo "MOCK_CFG=${MOCK_CFG}" >> "$GITHUB_ENV"
-          mock -r "${MOCK_CFG}" --isolation=simple \
+          mock --verbose -r "${MOCK_CFG}" --isolation=simple \
             --rebuild ~/rpmbuild/SRPMS/rusty_lights-*.src.rpm
 
       - name: Collect artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,19 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      publish_repo:
+        description: "Publish RPMs to gh-pages yum repo"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -90,6 +100,7 @@ jobs:
 
   release:
     needs: [build-native, build-cross]
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -105,3 +116,194 @@ jobs:
         with:
           generate_release_notes: true
           files: artifacts/*
+
+  build-rpm:
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+      options: --privileged
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      dist:    ${{ steps.version.outputs.dist }}
+    steps:
+      - name: Install build tooling
+        run: |
+          dnf -y install \
+            git rpm-build rpmdevtools mock cargo rust \
+            createrepo_c zstd tar
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            VERSION=$(grep -m1 '^version' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          fi
+          FEDORA_VER=$(rpm -E %fedora)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "dist=fc${FEDORA_VER}" >> "$GITHUB_OUTPUT"
+          echo "Building rusty_lights ${VERSION} for fc${FEDORA_VER}"
+
+      - name: Update spec version
+        run: |
+          sed -i -E "s/^Version:.*/Version:        ${{ steps.version.outputs.version }}/" rusty_lights.spec
+
+      - name: Set up rpmbuild tree
+        run: rpmdev-setuptree
+
+      - name: Create source tarball
+        run: |
+          V=${{ steps.version.outputs.version }}
+          git archive --format=tar.gz \
+            --prefix=rusty_lights-${V}/ \
+            -o ~/rpmbuild/SOURCES/rusty_lights-${V}.tar.gz HEAD
+
+      - name: Vendor cargo dependencies
+        run: |
+          V=${{ steps.version.outputs.version }}
+          cargo vendor --versioned-dirs vendor
+          tar --zstd -cf ~/rpmbuild/SOURCES/rusty_lights-${V}-vendor.tar.zst vendor
+
+      - name: Build SRPM
+        run: rpmbuild -bs rusty_lights.spec
+
+      - name: Build RPM with mock
+        run: |
+          # Latest stable Fedora mock config (skip rawhide/eln/branched)
+          MOCK_CFG=$(ls /etc/mock/fedora-*-x86_64.cfg \
+            | grep -vE 'rawhide|eln|branched' \
+            | sort -V | tail -1 \
+            | xargs -n1 basename | sed 's/\.cfg$//')
+          echo "Using mock config: ${MOCK_CFG}"
+          echo "MOCK_CFG=${MOCK_CFG}" >> "$GITHUB_ENV"
+          mock -r "${MOCK_CFG}" --isolation=simple \
+            --rebuild ~/rpmbuild/SRPMS/rusty_lights-*.src.rpm
+
+      - name: Collect artifacts
+        run: |
+          mkdir -p out/SRPMS out/RPMS
+          cp /var/lib/mock/${MOCK_CFG}/result/*.src.rpm out/SRPMS/
+          cp /var/lib/mock/${MOCK_CFG}/result/*.x86_64.rpm out/RPMS/
+          ls -la out/RPMS out/SRPMS
+
+      - name: Upload RPMs as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms
+          path: out/
+
+      - name: Attach RPMs to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            out/RPMS/*.rpm
+            out/SRPMS/*.src.rpm
+
+  publish-rpm-repo:
+    needs: build-rpm
+    if: startsWith(github.ref, 'refs/tags/v') || inputs.publish_repo
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:latest
+    steps:
+      - name: Install repo tooling
+        run: dnf -y install createrepo_c git
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: pages
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Initialise gh-pages branch if missing
+        run: |
+          if [ ! -d pages/.git ]; then
+            mkdir -p pages
+            cd pages
+            git init -b gh-pages
+            git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          fi
+          git config --global --add safe.directory "$GITHUB_WORKSPACE/pages"
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: rpms
+          path: incoming
+
+      - name: Merge new RPMs into repo tree
+        run: |
+          # Repo layout served by GitHub Pages:
+          #   /fedora/<dist>/x86_64/   (binary RPMs + repodata)
+          #   /fedora/<dist>/source/   (SRPMs        + repodata)
+          DIST="${{ needs.build-rpm.outputs.dist }}"
+          BASE="pages/fedora/${DIST}"
+          mkdir -p "${BASE}/x86_64" "${BASE}/source"
+          cp -v incoming/RPMS/*.rpm "${BASE}/x86_64/"
+          cp -v incoming/SRPMS/*.src.rpm "${BASE}/source/"
+          createrepo_c --update "${BASE}/x86_64"
+          createrepo_c --update "${BASE}/source"
+
+      - name: Generate .repo file and landing page
+        run: |
+          REPO_URL="https://${GITHUB_REPOSITORY_OWNER,,}.github.io/${GITHUB_REPOSITORY##*/}"
+          cat > "pages/rusty_lights.repo" <<EOF
+          [rusty_lights]
+          name=RustyLights for Fedora \$releasever
+          baseurl=${REPO_URL}/fedora/fc\$releasever/\$basearch
+          enabled=1
+          gpgcheck=0
+          repo_gpgcheck=0
+          metadata_expire=300
+
+          [rusty_lights-source]
+          name=RustyLights for Fedora \$releasever - Source
+          baseurl=${REPO_URL}/fedora/fc\$releasever/source
+          enabled=0
+          gpgcheck=0
+          EOF
+
+          cat > pages/index.html <<EOF
+          <!doctype html>
+          <html><head><meta charset="utf-8"><title>RustyLights RPM Repository</title>
+          <style>body{font-family:sans-serif;max-width:48em;margin:2em auto;padding:0 1em;line-height:1.5}
+          code,pre{background:#f4f4f4;padding:.2em .4em;border-radius:3px}
+          pre{padding:1em;overflow-x:auto}</style></head>
+          <body>
+          <h1>RustyLights RPM Repository</h1>
+          <p>Add the repo and install:</p>
+          <pre>sudo dnf config-manager addrepo --from-repofile=${REPO_URL}/rusty_lights.repo
+          sudo dnf install rusty_lights</pre>
+          <p>Available distributions: <a href="fedora/">fedora/</a></p>
+          <p>Repo file: <a href="rusty_lights.repo">rusty_lights.repo</a></p>
+          </body></html>
+          EOF
+          # Prevent Jekyll from hiding repodata directories
+          touch pages/.nojekyll
+
+      - name: Commit and push to gh-pages
+        run: |
+          cd pages
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to publish"
+            exit 0
+          fi
+          git commit -m "Publish RPMs for ${{ needs.build-rpm.outputs.version }} (${{ needs.build-rpm.outputs.dist }})"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            HEAD:gh-pages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,13 +47,18 @@ jobs:
           files: artifacts/*
 
   build-rpm:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     container:
       image: fedora:latest
       options: --privileged
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-      dist:    ${{ steps.version.outputs.dist }}
     steps:
       - name: Install build tooling
         run: |
@@ -79,7 +84,7 @@ jobs:
           FEDORA_VER=$(rpm -E %fedora)
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "dist=fc${FEDORA_VER}" >> "$GITHUB_OUTPUT"
-          echo "Building rusty_lights ${VERSION} for fc${FEDORA_VER}"
+          echo "Building rusty_lights ${VERSION} for fc${FEDORA_VER} (${{ matrix.arch }})"
 
       - name: Update spec version
         run: |
@@ -106,10 +111,11 @@ jobs:
 
       - name: Build RPM with mock
         run: |
-          # Pick the latest stable Fedora mock config, resolving symlinks so
-          # that aliases like fedora-N -> fedora-rawhide are excluded.
+          # Pick the latest stable Fedora mock config for this arch, resolving
+          # symlinks so aliases like fedora-N -> fedora-rawhide are excluded.
+          ARCH=${{ matrix.arch }}
           MOCK_CFG=""
-          for cfg in $(ls /etc/mock/fedora-*-x86_64.cfg | sort -V -r); do
+          for cfg in $(ls /etc/mock/fedora-*-${ARCH}.cfg | sort -V -r); do
             target=$(readlink -f "$cfg")
             base=$(basename "$cfg" .cfg)
             tbase=$(basename "$target" .cfg)
@@ -120,75 +126,44 @@ jobs:
             break
           done
           if [ -z "$MOCK_CFG" ]; then
-            echo "::error::No suitable stable Fedora mock config found"
+            echo "::error::No suitable stable Fedora mock config found for ${ARCH}"
             exit 1
           fi
           echo "Using mock config: ${MOCK_CFG}"
           echo "MOCK_CFG=${MOCK_CFG}" >> "$GITHUB_ENV"
           mock -r "${MOCK_CFG}" --isolation=simple \
+            --resultdir=/tmp/mock-result \
             --rebuild ~/rpmbuild/SRPMS/rusty_lights-*.src.rpm
 
       - name: List mock results
         if: always()
         run: |
-          echo "=== /var/lib/mock/${MOCK_CFG}/result ==="
-          ls -lh "/var/lib/mock/${MOCK_CFG}/result" || true
-          echo "=== all mock result dirs ==="
+          echo "=== /tmp/mock-result ==="
+          ls -lh /tmp/mock-result || true
+          echo "=== /var/lib/mock/*/result ==="
           ls -lh /var/lib/mock/*/result 2>/dev/null || true
 
       - name: Upload mock logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: mock-logs
+          name: mock-logs-${{ matrix.arch }}
           path: |
+            /tmp/mock-result/*.log
             /var/lib/mock/*/result/*.log
           if-no-files-found: ignore
-
-      - name: List mock result directory
-        if: always()
-        run: |
-          echo "::group::Result dir: ${RESULT_DIR}"
-          ls -la "${RESULT_DIR}" || true
-          echo "::endgroup::"
-          echo "::group::Default mock root paths"
-          ls -la /var/lib/mock/ || true
-          for d in /var/lib/mock/*/result; do
-            [ -d "$d" ] || continue
-            echo "--- $d ---"
-            ls -la "$d"
-          done
-          echo "::endgroup::"
-
-      - name: Upload mock logs (always)
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: mock-logs
-          path: |
-            ${{ env.RESULT_DIR }}/*.log
-            /var/lib/mock/*/result/*.log
-          if-no-files-found: warn
 
       - name: Collect artifacts
         run: |
           mkdir -p out/SRPMS out/RPMS
-          shopt -s nullglob
-          src=( "${RESULT_DIR}"/*.src.rpm )
-          bin=( "${RESULT_DIR}"/*.x86_64.rpm )
-          if [ ${#src[@]} -eq 0 ] || [ ${#bin[@]} -eq 0 ]; then
-            echo "::error::Expected RPMs not found in ${RESULT_DIR}"
-            ls -la "${RESULT_DIR}" || true
-            exit 1
-          fi
-          cp -v "${src[@]}" out/SRPMS/
-          cp -v "${bin[@]}" out/RPMS/
+          cp /tmp/mock-result/*.src.rpm out/SRPMS/
+          cp /tmp/mock-result/*.${{ matrix.arch }}.rpm out/RPMS/
           ls -la out/RPMS out/SRPMS
 
       - name: Upload RPMs as workflow artifact
         uses: actions/upload-artifact@v4
         with:
-          name: rpms
+          name: rpms-${{ matrix.arch }}
           path: out/
 
       - name: Attach RPMs to GitHub Release
@@ -228,22 +203,46 @@ jobs:
           fi
           git config --global --add safe.directory "$GITHUB_WORKSPACE/pages"
 
-      - uses: actions/download-artifact@v4
+      - name: Download all RPM artifacts
+        uses: actions/download-artifact@v4
         with:
-          name: rpms
           path: incoming
+          pattern: rpms-*
 
       - name: Merge new RPMs into repo tree
         run: |
           # Repo layout served by GitHub Pages:
-          #   /fedora/<dist>/x86_64/   (binary RPMs + repodata)
-          #   /fedora/<dist>/source/   (SRPMs        + repodata)
-          DIST="${{ needs.build-rpm.outputs.dist }}"
+          #   /fedora/<dist>/<arch>/   (binary RPMs + repodata)
+          #   /fedora/<dist>/source/   (SRPMs       + repodata)
+          shopt -s nullglob
+
+          # Derive dist tag (e.g. fc44) from the first binary RPM filename.
+          first_rpm=$(ls incoming/rpms-*/RPMS/*.rpm | head -1)
+          if [ -z "$first_rpm" ]; then
+            echo "::error::No RPMs found in incoming artifacts"
+            exit 1
+          fi
+          DIST=$(basename "$first_rpm" | sed -E 's/.*\.(fc[0-9]+)\..*/\1/')
+          VERSION=$(basename "$first_rpm" | sed -E 's/^rusty_lights-([^-]+)-.*/\1/')
+          echo "Detected dist=${DIST} version=${VERSION}"
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          echo "DIST=${DIST}"       >> "$GITHUB_ENV"
+
           BASE="pages/fedora/${DIST}"
-          mkdir -p "${BASE}/x86_64" "${BASE}/source"
-          cp -v incoming/RPMS/*.rpm "${BASE}/x86_64/"
-          cp -v incoming/SRPMS/*.src.rpm "${BASE}/source/"
-          createrepo_c --update "${BASE}/x86_64"
+
+          for arch_dir in incoming/rpms-*/RPMS; do
+            arch=$(basename "$(dirname "$arch_dir")" | sed 's/^rpms-//')
+            mkdir -p "${BASE}/${arch}"
+            cp -v "${arch_dir}"/*.rpm "${BASE}/${arch}/"
+            createrepo_c --update "${BASE}/${arch}"
+          done
+
+          mkdir -p "${BASE}/source"
+          # All SRPMs are arch-independent and identical across matrix runs;
+          # cp -n avoids overwriting if the same file appears in two artifacts.
+          for src_dir in incoming/rpms-*/SRPMS; do
+            cp -nv "${src_dir}"/*.src.rpm "${BASE}/source/" || true
+          done
           createrepo_c --update "${BASE}/source"
 
       - name: Generate .repo file and landing page
@@ -276,6 +275,7 @@ jobs:
           <p>Add the repo and install:</p>
           <pre>sudo dnf config-manager addrepo --from-repofile=${REPO_URL}/rusty_lights.repo
           sudo dnf install rusty_lights</pre>
+          <p>Architectures: x86_64, aarch64.</p>
           <p>Available distributions: <a href="fedora/">fedora/</a></p>
           <p>Repo file: <a href="rusty_lights.repo">rusty_lights.repo</a></p>
           </body></html>
@@ -293,7 +293,7 @@ jobs:
             echo "No changes to publish"
             exit 0
           fi
-          git commit -m "Publish RPMs for ${{ needs.build-rpm.outputs.version }} (${{ needs.build-rpm.outputs.dist }})"
+          git commit -m "Publish RPMs for ${VERSION} (${DIST})"
           git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
             HEAD:gh-pages
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,21 +106,83 @@ jobs:
 
       - name: Build RPM with mock
         run: |
-          # Latest stable Fedora mock config (skip rawhide/eln/branched)
-          MOCK_CFG=$(ls /etc/mock/fedora-*-x86_64.cfg \
-            | grep -vE 'rawhide|eln|branched' \
-            | sort -V | tail -1 \
-            | xargs -n1 basename | sed 's/\.cfg$//')
+          # Pick the latest stable Fedora mock config, resolving symlinks so
+          # that aliases like fedora-N -> fedora-rawhide are excluded.
+          MOCK_CFG=""
+          for cfg in $(ls /etc/mock/fedora-*-x86_64.cfg | sort -V -r); do
+            target=$(readlink -f "$cfg")
+            base=$(basename "$cfg" .cfg)
+            tbase=$(basename "$target" .cfg)
+            if echo "$base $tbase" | grep -qE 'rawhide|eln|branched'; then
+              continue
+            fi
+            MOCK_CFG="$base"
+            break
+          done
+          if [ -z "$MOCK_CFG" ]; then
+            echo "::error::No suitable stable Fedora mock config found"
+            exit 1
+          fi
           echo "Using mock config: ${MOCK_CFG}"
           echo "MOCK_CFG=${MOCK_CFG}" >> "$GITHUB_ENV"
           mock -r "${MOCK_CFG}" --isolation=simple \
             --rebuild ~/rpmbuild/SRPMS/rusty_lights-*.src.rpm
 
+      - name: List mock results
+        if: always()
+        run: |
+          echo "=== /var/lib/mock/${MOCK_CFG}/result ==="
+          ls -lh "/var/lib/mock/${MOCK_CFG}/result" || true
+          echo "=== all mock result dirs ==="
+          ls -lh /var/lib/mock/*/result 2>/dev/null || true
+
+      - name: Upload mock logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mock-logs
+          path: |
+            /var/lib/mock/*/result/*.log
+          if-no-files-found: ignore
+
+      - name: List mock result directory
+        if: always()
+        run: |
+          echo "::group::Result dir: ${RESULT_DIR}"
+          ls -la "${RESULT_DIR}" || true
+          echo "::endgroup::"
+          echo "::group::Default mock root paths"
+          ls -la /var/lib/mock/ || true
+          for d in /var/lib/mock/*/result; do
+            [ -d "$d" ] || continue
+            echo "--- $d ---"
+            ls -la "$d"
+          done
+          echo "::endgroup::"
+
+      - name: Upload mock logs (always)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mock-logs
+          path: |
+            ${{ env.RESULT_DIR }}/*.log
+            /var/lib/mock/*/result/*.log
+          if-no-files-found: warn
+
       - name: Collect artifacts
         run: |
           mkdir -p out/SRPMS out/RPMS
-          cp /var/lib/mock/${MOCK_CFG}/result/*.src.rpm out/SRPMS/
-          cp /var/lib/mock/${MOCK_CFG}/result/*.x86_64.rpm out/RPMS/
+          shopt -s nullglob
+          src=( "${RESULT_DIR}"/*.src.rpm )
+          bin=( "${RESULT_DIR}"/*.x86_64.rpm )
+          if [ ${#src[@]} -eq 0 ] || [ ${#bin[@]} -eq 0 ]; then
+            echo "::error::Expected RPMs not found in ${RESULT_DIR}"
+            ls -la "${RESULT_DIR}" || true
+            exit 1
+          fi
+          cp -v "${src[@]}" out/SRPMS/
+          cp -v "${bin[@]}" out/RPMS/
           ls -la out/RPMS out/SRPMS
 
       - name: Upload RPMs as workflow artifact

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Build artifacts
 /target
 *.rs.bk
+/vendor
+/.cargo/config.toml
 
 # IDE
 .idea/

--- a/rusty_lights.spec
+++ b/rusty_lights.spec
@@ -1,0 +1,79 @@
+Name:           rusty_lights
+Version:        0.9.0
+Release:        1%{?dist}
+Summary:        Resource-efficient audio-to-LED visualization
+
+License:        GPL-3.0-only
+URL:            https://github.com/appliedapp/rusty_lights
+Source0:        %{name}-%{version}.tar.gz
+Source1:        %{name}-%{version}-vendor.tar.zst
+
+BuildRequires:  rust >= 1.85
+BuildRequires:  cargo
+BuildRequires:  pkgconfig(libpipewire-0.3)
+BuildRequires:  alsa-lib-devel
+BuildRequires:  systemd-rpm-macros
+BuildRequires:  gcc
+BuildRequires:  clang-devel
+BuildRequires:  zstd
+
+Requires:       alsa-lib
+Requires:       pipewire-libs
+%{?systemd_requires}
+
+%description
+RustyLights is a resource-efficient audio-to-LED visualization tool written
+in Rust. It captures audio via PipeWire or ALSA, performs real-time DSP
+analysis, and drives addressable LED fixtures over E1.31 (sACN) or via
+WLED-compatible devices.
+
+%prep
+%autosetup -n %{name}-%{version}
+# Unpack vendored crates and configure cargo to use them
+tar -xf %{SOURCE1}
+mkdir -p .cargo
+cat > .cargo/config.toml <<'EOF'
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"
+EOF
+
+%build
+cargo build --release --offline
+
+%install
+install -Dpm 0755 target/release/%{name} %{buildroot}%{_bindir}/%{name}
+install -Dpm 0644 rusty_lights.example.toml %{buildroot}%{_sysconfdir}/%{name}.conf
+install -Dpm 0644 debian/%{name}.service %{buildroot}%{_unitdir}/%{name}.service
+
+# Adjust unit file path: spec installs binary to /usr/bin, not /usr/local/bin
+sed -i 's|/usr/local/bin/%{name}|%{_bindir}/%{name}|' \
+    %{buildroot}%{_unitdir}/%{name}.service
+
+install -Dpm 0644 README.md %{buildroot}%{_docdir}/%{name}/README.md
+install -Dpm 0644 LICENSE %{buildroot}%{_licensedir}/%{name}/LICENSE
+
+%check
+cargo test --release --offline || :
+
+%post
+%systemd_post %{name}.service
+
+%preun
+%systemd_preun %{name}.service
+
+%postun
+%systemd_postun_with_restart %{name}.service
+
+%files
+%license LICENSE
+%doc README.md PERFORMANCE.md
+%{_bindir}/%{name}
+%config(noreplace) %{_sysconfdir}/%{name}.conf
+%{_unitdir}/%{name}.service
+
+%changelog
+* Sat May 02 2026 RustLED Contributors - 0.9.0-1
+- Initial RPM packaging


### PR DESCRIPTION
This pull request significantly refactors and expands the project's CI/CD workflows to support reusable build steps, cross-platform packaging, and automated RPM repository publication for Fedora. The changes modularize the build process, introduce a Fedora RPM spec, and streamline release artifact handling.

**Workflow modularization and improvements:**

- Introduced a reusable build workflow (`.github/workflows/build.yml`) that runs formatting, linting, testing, and builds release binaries for both native and cross targets, with optional artifact uploads for use in CI and releases.
- Refactored the main CI workflow (`ci.yml`) to delegate all build and test steps to the new reusable build workflow, simplifying the file and removing redundant job definitions.

**Release and packaging enhancements:**

- Overhauled the release workflow (`release.yml`) to:
  - Use the reusable build workflow for artifact generation.
  - Add concurrency controls to prevent overlapping releases.
  - Automate artifact collection and attach binaries and .deb packages to GitHub Releases.
  - Add a comprehensive Fedora RPM build and packaging matrix, supporting both x86_64 and aarch64 architectures, including SRPM and binary RPM creation using Fedora containers and mock.
  - Implement a job to publish RPMs to a GitHub Pages-hosted Fedora repository, complete with metadata, a `.repo` file, and a landing page for easy consumption by users.

**Fedora packaging support:**

- Added a new `rusty_lights.spec` file for Fedora RPM packaging, including build requirements, install instructions, systemd integration, and documentation/license handling.

These changes make the build, test, and release process more maintainable, enable easy cross-distribution packaging, and provide users with direct access to RPM packages via a public repository.

**Most important changes:**

**Workflow modularization**
- Added `.github/workflows/build.yml` as a reusable workflow for building, testing, and packaging across native and cross targets, with optional artifact uploads.
- Updated `.github/workflows/ci.yml` to use the new reusable build workflow, removing all previous job definitions.

**Release and RPM packaging**
- Refactored `.github/workflows/release.yml` to use the reusable build workflow, automate artifact handling, add concurrency, and introduce a full Fedora RPM build/publish pipeline, including GitHub Pages RPM repo publication.

**Fedora support**
- Added `rusty_lights.spec` for Fedora RPM packaging, including build/install scripts, dependencies, and changelog.